### PR TITLE
認証追加

### DIFF
--- a/back-admin/app/controllers/TestController.php
+++ b/back-admin/app/controllers/TestController.php
@@ -1,0 +1,12 @@
+<?php
+
+class TestController extends BaseController {
+
+	public function getIndex()
+	{
+		return View::make('top.index');
+		// echo "hoge";
+	}
+
+
+}

--- a/back-admin/app/controllers/TopController.php
+++ b/back-admin/app/controllers/TopController.php
@@ -1,0 +1,12 @@
+<?php
+
+class TopController extends BaseController {
+
+	public function getIndex()
+	{
+		return View::make('top.index');
+		// echo "hoge";
+	}
+
+
+}

--- a/back-admin/app/controllers/UserController.php
+++ b/back-admin/app/controllers/UserController.php
@@ -1,0 +1,90 @@
+<?php
+
+class UserController extends BaseController {
+
+	public function getIndex()
+	{
+		return View::make('users.index');
+	}
+
+
+	public function getCreate()
+	{
+		return View::make('users.create');
+	}
+
+	public function postCreate()
+	{
+	//トークンチェック
+	if (Session::getToken() != Input::get('_token'))
+	{
+		throw new Illuminate\Session\TokenMismatchException;
+	}else{
+		$inputs=Input::all();
+		//バリデーションルールの指定
+		$rules = array (
+		'username' => array ( 'required', 'min:4', 'max:50', 'unique:users' ),
+		'password' => array ( 'required', 'min:4', 'max:50' ),
+		);
+		$val = Validator::make( $inputs, $rules );
+		//バリデーションNGなら 
+		if ( $val->fails() )
+		{
+		return Redirect::back()->withErrors( $val )->withInput();
+		}
+		//ユーザーの新規作成
+		$user=new User;
+		$user->username=Input::get('username');
+		$user->service_id=Input::get('service_id');
+		$user->group_id=Input::get('group_id');
+		$user->password=Hash::make(Input::get('password'));
+		$user->save();
+		//トップページへリダイレクト
+		return Redirect::to('users');
+		}
+	}
+
+	public function getLogin()
+	{
+		return View::make('users.login');
+	}
+
+	public function postLogin()
+	{
+		//入力データの取得
+		$inputs = Input::only(array('username', 'password'));
+		//バリデーションルールの作成
+		$rules = array (
+		'username' => array ('required'),
+		'password' => array ('required'),
+		);
+		//バリデーション処理
+		$val = Validator::make( $inputs, $rules ); 
+		//バリデーションNGなら
+		if($val->fails())
+		{
+		//エラー値と一緒にバック
+		return Redirect::back()
+		->withErrors( $val )
+		->withInput();
+		}
+		//認証NGなら
+		if(!Auth::attempt($inputs))
+		{
+		return Redirect::back()
+		->withErrors(array('warning'=>'ユーザー名かパスワードが違います。'))
+		->withInput();
+		}
+		//TOPページへ
+		return Redirect::to('/top');
+	}
+
+	public function getLogout()
+	{
+		Auth::logout();
+		return Redirect::to('/users/login');
+	}
+
+
+
+}

--- a/back-admin/app/filters.php
+++ b/back-admin/app/filters.php
@@ -43,7 +43,25 @@ Route::filter('auth', function()
 		}
 		else
 		{
-			return Redirect::guest('login');
+			return Redirect::guest('users/login');
+		}
+	}
+});
+
+Route::filter('group0', function()
+{
+	if(Auth::check()){
+		if(Auth::user()->group_id != 0){
+			return Redirect::guest('users/login');
+		}
+	}
+});
+
+Route::filter('group1', function()
+{
+	if(Auth::check()){
+		if(Auth::user()->group_id != 1){
+			return Redirect::guest('users/login');
 		}
 	}
 });

--- a/back-admin/app/routes.php
+++ b/back-admin/app/routes.php
@@ -11,7 +11,33 @@
 |
 */
 
-Route::get('/', function()
+
+
+
+Route::group(array('before' => array('auth')),function(){
+	if(Auth::check()){
+		switch(Auth::user()->group_id){
+			case 0:
+				Route::get('/top', function()
+				{
+					return View::make('top.group0');
+				});
+				break;
+			case 1:
+				Route::get('/top', function()
+				{
+					return View::make('top.group1');
+				});
+				break;
+		}
+	} 
+});
+
+
+
+Route::controller('users','UserController');
+
+Route::get('/',function()
 {
-	return View::make('hello');
+	return Redirect::to('/users/login');
 });

--- a/back-admin/app/views/layouts/master.blade.php
+++ b/back-admin/app/views/layouts/master.blade.php
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>laravel調査</title>
+</head>
+<body>
+<div id="container">
+	<div id="header" class="clearfix">
+		<a href="/">laravel調査</a>
+		<a href="/users/create">ユーザ作成</a>
+		<a href="/users/login">ログイン</a>
+		<a href="/users/logout">ログアウト</a>
+	</div>
+	<div id="wrap">
+		<div id="content_wrap">
+			<div id="content">
+				@section('content')	
+				@show
+			</div>
+		</div>
+	</div>
+</div>
+
+</body>
+</html>

--- a/back-admin/app/views/top/group0.blade.php
+++ b/back-admin/app/views/top/group0.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.master')
+@section('content')
+	@parent
+	<h2>グループ0用Topページ</h2>
+	<h4>作成中<h4>
+
+@stop

--- a/back-admin/app/views/top/group1.blade.php
+++ b/back-admin/app/views/top/group1.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.master')
+@section('content')
+	@parent
+	<h2>グループ1用Topページ</h2>
+	<h4>作成中<h4>
+
+@stop

--- a/back-admin/app/views/top/index.blade.php
+++ b/back-admin/app/views/top/index.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.master')
+@section('content')
+	@parent
+	<h2>/top/index</h2>
+
+@stop

--- a/back-admin/app/views/users/create.blade.php
+++ b/back-admin/app/views/users/create.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts.master')
+@section('content')
+	@parent
+	<h2>ログインユーザ作成</h2>
+
+	{{ Form::open(array('class'=>'form-horizontal')) }}
+
+	<div class="control-group">
+		{{ Form::label('username','ユーザー名',array('class'=>'control-label')) }}
+		<div class="controls">
+		{{ Form::text('username') }}
+		@if($errors->has('username'))
+		</div>
+		<div class="controls label label-important">
+		{{ $errors->first('username') }}
+		@endif
+		</div>
+	</div>
+
+	<div class="control-group">
+		{{ Form::label('password','パスワード',array('class'=>'control-label')) }}
+		<div class="controls">
+		{{ Form::text('password') }}
+		@if($errors->has('password'))
+		</div>
+		<div class="controls label label-important">
+		{{ $errors->first('password') }}
+		@endif
+		</div>
+	</div>
+
+	<div class="control-group">
+		{{ Form::label('service_id','サービスID',array('class'=>'control-label')) }}
+		<div class="controls">
+		{{ Form::text('service_id') }}
+		@if($errors->has('service_id'))
+		</div>
+		<div class="controls label label-important">
+		{{ $errors->first('service_id') }}
+		@endif
+		</div>
+	</div>
+
+	<div class="control-group">
+		{{ Form::label('group_id','グループID',array('class'=>'control-label')) }}
+		<div class="controls">
+		{{ Form::text('group_id') }}
+		@if($errors->has('group_id'))
+		</div>
+		<div class="controls label label-important">
+		{{ $errors->first('group_id') }}
+		@endif
+		</div>
+	</div>
+	
+	<div class="form-actions">
+		{{ Form::submit('新規登録',array('class'=>'btn btn-primary')) }}
+	</div>
+	{{ Form::token() }}
+	{{ Form::close() }}
+
+@stop

--- a/back-admin/app/views/users/index.blade.php
+++ b/back-admin/app/views/users/index.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.master')
+@section('content')
+	@parent
+	<h2>ログインユーザ一覧</h2>
+	<h4>作成中<h4>
+
+@stop

--- a/back-admin/app/views/users/login.blade.php
+++ b/back-admin/app/views/users/login.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.master')
+@section('content')
+	@parent
+	<h2>ログイン</h2>
+
+	{{ Form::open(array('class'=>'form-horizontal')) }}
+
+	<div class="control-group">
+		{{ Form::label('username','ユーザー名',array('class'=>'control-label')) }}
+		<div class="controls">
+		{{ Form::text('username') }}
+		@if($errors->has('username'))
+		</div>
+		<div class="controls label label-important">
+		{{ $errors->first('username') }}
+		@endif
+		</div>
+	</div>
+
+	<div class="control-group">
+		{{ Form::label('password','パスワード',array('class'=>'control-label')) }}
+		<div class="controls">
+		{{ Form::text('password') }}
+		@if($errors->has('password'))
+		</div>
+		<div class="controls label label-important">
+		{{ $errors->first('password') }}
+		@endif
+		</div>
+	</div>
+
+	@if($errors->has('warning'))
+	<div class="alert alert-error" id="alert">
+		{{ $errors->first('warning') }}
+	</div>
+	@endif
+
+	
+	<div class="form-actions">
+		{{ Form::submit('新規登録',array('class'=>'btn btn-primary')) }}
+	</div>
+	{{ Form::token() }}
+	{{ Form::close() }}
+
+@stop

--- a/front-common/database/migrations/2014_11_04_044925_users.php
+++ b/front-common/database/migrations/2014_11_04_044925_users.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class Users extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('users', function(Blueprint $table)
+		{
+			$table->increments('id');
+			$table->integer('service_id');
+			$table->text('username');
+			$table->text('password');
+			$table->integer('group_id');
+			$table->dateTime('updated_at');
+			$table->dateTime('created_at');
+			$table->rememberToken();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop('users');
+	}
+
+}


### PR DESCRIPTION
# 組み込みの認証機能を追加
## 構成等について
### TBMの構成には似せてページを構成
- /users/login ログイン
- /users/logout ログアウト
- /top ログイン後のトップページ

### usersテーブルの相違点
- (TBM) created => (laravel) created_at
- (TBM) modified => (laravel) updated_at
- remember_tokenの追加

##### マイグレーションファイル
- 2014_11_04_044925_users.php にusersテーブルのマイグレーションファイルを置いてあります

## 調査
### routes.phpの記述についての考察
認証ユーザの所属グループによって表示内容を変化させる件について
##### フィルターを用いた問題点

```php
// routes.php
Route::group(array('before' => array('auth','group0')),function(){
	Route::get('/top', function()
	{
		return View::make('top.group0');
	});
});

Route::group(array('before' => array('auth','group1')),function(){
	Route::get('/top', function()
	{
		return View::make('top.group1');
	});
});
```

```php
// filters.php
Route::filter('group0', function()
{
	if(Auth::check()){
		if(Auth::user()->group_id != 0){
			return Redirect::guest('users/login');
		}
	}
});

Route::filter('group1', function()
{
	if(Auth::check()){
		if(Auth::user()->group_id != 1){
			return Redirect::guest('users/login');
		}
	}
});
```
このような記述をした場合、/topにアクセス（ログイン済）した場合、
- `authフィルター` => `group0フィルター` => `authフィルター` => `group1フィルター` の順番で通ってしまう（Route::group記述を二回しているので、グループ0がOKでもグループ1のフィルタを通ってしまう）ため、group0ユーザであった場合、グループ1のフィルターで弾かれてしまう。

##### フィルタを使わないとしたら
```php
// routes.php
Route::group(array('before' => array('auth')),function(){
	if(Auth::check()){
	// authフィルターで弾かれた場合も以下を通るため、現状ではエラー回避のためにAuth::check記述をしている
		switch(Auth::user()->group_id){
			case 0:
				Route::get('/top', function()
				{
					return View::make('top.group0');
				});
				break;
			case 1:
				Route::get('/top', function()
				{
					return View::make('top.group1');
				});
				break;
		}
	} 
});
```
現状ではこのような記述にしてしまっている。
